### PR TITLE
fix map override

### DIFF
--- a/app/providers/decidim/map/provider/dynamic_map/swisstopo.rb
+++ b/app/providers/decidim/map/provider/dynamic_map/swisstopo.rb
@@ -17,7 +17,7 @@ module Decidim
             # @see Decidim::Map::DynamicMap::Builder#javascript_snippets
             def javascript_snippets
               [
-                  template.javascript_pack_tag("decidim/swisstopo")
+                  template.javascript_pack_tag("decidim/swisstopo", defer: false)
               ].join
             end
           end

--- a/app/views/decidim/shared/_static_map.html.erb
+++ b/app/views/decidim/shared/_static_map.html.erb
@@ -16,8 +16,6 @@
               <h5>${title}</h5>
             </div>
           </template>
-          <%= stylesheet_link_tag "decidim/map" %>
-          <%= javascript_include_tag "decidim/map" %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
This PR should fix the javascript errors derived from the override of the default map controller.

The main problem is that the original javascripts assets are rendered with the property `defer: false` while the override no. This makes the map controller not available at the time of initialization by other scripts.

