### PR TITLE
Fix organization name in devise emails

### DIFF
--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,9 +1,0 @@
-<% scope = Decidim.config.devise_custom_scope.(@organization) %>
-
-<p><%=t('.greeting', scope: scope, recipient: @email) %></p>
-
-<% if @resource.try(:unconfirmed_email?) %>
-  <p><%= t('.message_unconfirmed', scope: scope, email: @resource.unconfirmed_email) %></p>
-<% else %>
-  <p><%= t('.message', scope: scope, email: @resource.email) %></p>
-<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,15 +1,15 @@
 <% scope = Decidim.config.devise_custom_scope.(@organization) %>
 
-<p class="email-greeting"><%= t(".hello", scope: scope, email: @resource.name) %></p>
+<p class="email-greeting"><%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.name) %></p>
 
 <p class="email-instructions">
-  <%= t(".someone_invited_you", scope: scope, application: @resource.organization.name) %>
+  <%= t("devise.mailer.invitation_instructions.someone_invited_you", application: organization_name(@resource.organization)) %>
 </p>
 
-<p class="email-button email-button__cta"><%= link_to t(".accept", scope: scope), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim.root_path, host: @resource.organization.host) %></p>
+<p class="email-button email-button__cta"><%= link_to t("devise.mailer.invitation_instructions.accept", scope: scope), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim.root_path, host: @resource.organization.host) %></p>
 
 <% if @resource.invitation_due_at %>
-  <p class="email-small"><%= t(".accept_until", scope: scope, due_date: l(@resource.invitation_due_at, format: :long)) %></p>
+  <p class="email-small"><%= t("devise.mailer.invitation_instructions.accept_until", scope: scope, due_date: l(@resource.invitation_due_at, format: :long)) %></p>
 <% end %>
 
-<p class="email-small email-closing"><%= t(".ignore", scope: scope).html_safe %></p>
+<p class="email-small email-closing"><%= t("devise.mailer.invitation_instructions.ignore", scope: scope).html_safe %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,13 +1,13 @@
 <% scope = Decidim.config.devise_custom_scope.(@organization) %>
 
-<%= t(".hello", scope: scope, email: @resource.name) %>
+<%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.name) %>
 
-<%= t(".someone_invited_you", scope: scope, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", scope: scope, application: organization_name(@resource.organization)) %>
 
 <%= accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim.root_path, host: @resource.organization.host) %>
 
 <% if @resource.invitation_due_at %>
-  <%= t(".accept_until", scope: scope, due_date: l(@resource.invitation_due_at, format: :long)) %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", scope: scope, due_date: l(@resource.invitation_due_at, format: :long)) %>
 <% end %>
 
-<%= strip_tags t(".ignore", scope: scope) %>
+<%= strip_tags t("devise.mailer.invitation_instructions.ignore", scope: scope) %>

--- a/app/views/devise/mailer/invite_admin.html.erb
+++ b/app/views/devise/mailer/invite_admin.html.erb
@@ -4,9 +4,9 @@
 
 <p class="email-instructions">
   <% if @resource.invited_by.present? %>
-    <%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
   <% else %>
-    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: organization_name(@resource.organization)) %>
   <% end %>
 </p>
 

--- a/app/views/devise/mailer/invite_admin.text.erb
+++ b/app/views/devise/mailer/invite_admin.text.erb
@@ -3,9 +3,9 @@
 <%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.name) %>
 
 <% if @resource.invited_by.present? %>
-<%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
 <% else %>
-<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: organization_name(@resource.organization)) %>
 <% end %>
 
 <%= accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %>

--- a/app/views/devise/mailer/invite_collaborator.html.erb
+++ b/app/views/devise/mailer/invite_collaborator.html.erb
@@ -4,9 +4,9 @@
 
 <p class="email-instructions">
   <% if @resource.invited_by.present? %>
-    <%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
   <% else %>
-    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: organization_name(@resource.organization)) %>
   <% end %>
 </p>
 

--- a/app/views/devise/mailer/invite_collaborator.text.erb
+++ b/app/views/devise/mailer/invite_collaborator.text.erb
@@ -3,9 +3,9 @@
 <%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.name) %>
 
 <% if @resource.invited_by.present? %>
-<%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.invited_you_as_admin", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
 <% else %>
-<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_admin", scope: scope, application: organization_name(@resource.organization)) %>
 <% end %>
 
 <%= accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %>

--- a/app/views/devise/mailer/invite_private_user.html.erb
+++ b/app/views/devise/mailer/invite_private_user.html.erb
@@ -4,9 +4,9 @@
 
 <p class="email-instructions">
   <% if @resource.invited_by.present? %>
-    <%= t("devise.mailer.invitation_instructions.invited_you_as_private_user", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.invited_you_as_private_user", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
   <% else %>
-    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_private_user", scope: scope, application: @resource.organization.name) %>
+    <%= t("devise.mailer.invitation_instructions.someone_invited_you_as_private_user", scope: scope, application: organization_name(@resource.organization)) %>
   <% end %>
 </p>
 

--- a/app/views/devise/mailer/invite_private_user.text.erb
+++ b/app/views/devise/mailer/invite_private_user.text.erb
@@ -3,9 +3,9 @@
 <%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.name) %>
 
 <% if @resource.invited_by.present? %>
-<%= t("devise.mailer.invitation_instructions.invited_you_as_private_user", scope: scope, invited_by: @resource.invited_by.name, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.invited_you_as_private_user", scope: scope, invited_by: @resource.invited_by.name, application: organization_name(@resource.organization)) %>
 <% else %>
-<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_private_user", scope: scope, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you_as_private_user", scope: scope, application: organization_name(@resource.organization)) %>
 <% end %>
 
 <%= accept_invitation_url(@resource, invitation_token: @token, host: @resource.organization.host) %>

--- a/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
+++ b/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p class="email-greeting"><%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.email) %></p>
 
-<p class="email-instructions"><%= t("devise.mailer.invitation_instructions.someone_invited_you", scope: scope, application: @resource.organization.name) %></p>
+<p class="email-instructions"><%= t("devise.mailer.invitation_instructions.someone_invited_you", scope: scope, application: organization_name(@resource.organization)) %></p>
 
 <p class="email-button email-button__cta"><%= link_to t("devise.mailer.invitation_instructions.accept", scope: scope), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %></p>
 

--- a/app/views/devise/mailer/organization_admin_invitation_instructions.text.erb
+++ b/app/views/devise/mailer/organization_admin_invitation_instructions.text.erb
@@ -2,7 +2,7 @@
 
 <%= t("devise.mailer.invitation_instructions.hello", scope: scope, email: @resource.email) %>
 
-<%= t("devise.mailer.invitation_instructions.someone_invited_you", scope: scope, application: @resource.organization.name) %>
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", scope: scope, application: organization_name(@resource.organization)) %>
 
 <%= accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %>
 


### PR DESCRIPTION
Re-implementing the fix from 6094ce59 with the up-to-date versions of these templates.
Fixes #333